### PR TITLE
Refresh manifest pinned SHA for containers main

### DIFF
--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -129,7 +129,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "8ef6e33155b5fc3af382fea03f5e08d0bc04e217"
+      "pinned_sha": "7459d4fa19d2288f834f4b245dc0a87e01fdaed4"
     },
     {
       "path": "C:\\dev\\labview-for-containers-org",


### PR DESCRIPTION
## Summary
- Update `workspace-governance.json` pinned SHA for `LabVIEW-Community-CI-CD/labview-for-containers:main`.
- Clear drift detected by `Workspace SHA Drift Signal`.

## Validation
- Ran drift check locally: `status=in_sync`, `drift_count=0`.
- Ran contract tests: `9 passed, 0 failed`.

## Signal Context
- Failing on-demand drift run (expected before refresh):
  - https://github.com/LabVIEW-Community-CI-CD/labview-cdev-surface/actions/runs/22267745573