### PR TITLE
Unblock auto-refresh auto-merge without self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
 
   workspace-installer-contract:
     name: Workspace Installer Contract
+    if: ${{ vars.ENABLE_SELF_HOSTED_CONTRACTS == 'true' }}
     runs-on: [self-hosted, windows, self-hosted-windows-lv]
     needs: [ci-pipeline]
     steps:
@@ -136,6 +137,7 @@ jobs:
 
   reproducibility-contract:
     name: Reproducibility Contract
+    if: ${{ vars.ENABLE_SELF_HOSTED_CONTRACTS == 'true' }}
     runs-on: [self-hosted, windows, self-hosted-windows-lv]
     needs: [ci-pipeline]
     steps:
@@ -216,6 +218,7 @@ jobs:
 
   provenance-contract:
     name: Provenance Contract
+    if: ${{ vars.ENABLE_SELF_HOSTED_CONTRACTS == 'true' }}
     runs-on: [self-hosted, windows, self-hosted-windows-lv]
     needs: [reproducibility-contract]
     steps:

--- a/.github/workflows/workspace-sha-refresh-pr.yml
+++ b/.github/workflows/workspace-sha-refresh-pr.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -94,6 +95,20 @@ jobs:
           add-paths: |
             workspace-governance.json
             workspace-governance-payload/workspace-governance/workspace-governance.json
+
+      - name: Dispatch CI Pipeline for refresh branch
+        if: steps.create_pr.outputs.pull-request-number != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & gh workflow run ci.yml `
+            --repo "${{ github.repository }}" `
+            --ref automation/sha-refresh
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to dispatch CI Pipeline for automation/sha-refresh."
+          }
 
       - name: Enable squash auto-merge for refresh PR
         if: steps.create_pr.outputs.pull-request-number != ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,10 +35,13 @@ This repository is the canonical policy and manifest surface for deterministic `
 - Phase-1 release policy is unsigned installer with mandatory SHA256 provenance in release notes.
 
 ## Installer Build Contract
-- `CI Pipeline` must include `Workspace Installer Contract`.
+- `CI Pipeline` (GitHub-hosted) is the required merge check.
+- Self-hosted contract lanes are opt-in via repository variable `ENABLE_SELF_HOSTED_CONTRACTS=true`.
+- If no self-hosted runner is configured, self-hosted lanes must remain skipped and non-blocking.
+- When self-hosted lanes are enabled, `CI Pipeline` must include `Workspace Installer Contract`.
 - The contract job must stage deterministic payload inputs from `workspace-governance-payload`, bundle `runner-cli` from manifest-pinned icon-editor SHA, and build `lvie-cdev-workspace-installer.exe` with NSIS on self-hosted Windows.
 - The job must publish the built installer as a workflow artifact.
-- `CI Pipeline` must also include:
+- When self-hosted lanes are enabled, `CI Pipeline` must also include:
   - `Reproducibility Contract` (bit-for-bit hash checks for runner-cli and installer).
   - `Provenance Contract` (SPDX/SLSA generation + hash-link validation).
 - Keep default-branch required checks unchanged until branch-protection contract is intentionally updated.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ pwsh -NoProfile -File .\scripts\Invoke-WorkspaceInstallerIteration.ps1 `
 
 ## Build in CI
 
-`CI Pipeline` includes the `Workspace Installer Contract` job, which compiles:
+`CI Pipeline` always runs on GitHub-hosted Linux and is the required merge check.
+
+Self-hosted contract jobs are opt-in via repository variable `ENABLE_SELF_HOSTED_CONTRACTS=true`.
+If no self-hosted runner is configured, these jobs stay skipped and do not block merge policy.
+
+When enabled, `Workspace Installer Contract` compiles:
 - `lvie-cdev-workspace-installer.exe`
 
 The job stages a deterministic workspace payload, builds a manifest-pinned `runner-cli` bundle, and validates that NSIS build tooling can produce the installer on the self-hosted Windows lane.

--- a/tests/WorkspaceShaRefreshPrContract.Tests.ps1
+++ b/tests/WorkspaceShaRefreshPrContract.Tests.ps1
@@ -17,6 +17,7 @@ Describe 'Workspace SHA refresh PR workflow contract' {
     It 'is schedule and dispatch driven with write permissions' {
         $script:workflowContent | Should -Match 'schedule:'
         $script:workflowContent | Should -Match 'workflow_dispatch:'
+        $script:workflowContent | Should -Match 'actions:\s*write'
         $script:workflowContent | Should -Match 'contents:\s*write'
         $script:workflowContent | Should -Match 'pull-requests:\s*write'
     }
@@ -32,5 +33,10 @@ Describe 'Workspace SHA refresh PR workflow contract' {
         $script:workflowContent | Should -Match 'gh pr merge'
         $script:workflowContent | Should -Match '--auto'
         $script:workflowContent | Should -Match '--squash'
+    }
+
+    It 'dispatches CI Pipeline for automation branch' {
+        $script:workflowContent | Should -Match 'gh workflow run ci\.yml'
+        $script:workflowContent | Should -Match '--ref automation/sha-refresh'
     }
 }

--- a/tests/WorkspaceSurfaceContract.Tests.ps1
+++ b/tests/WorkspaceSurfaceContract.Tests.ps1
@@ -129,6 +129,7 @@ Describe 'Workspace surface contract' {
         $script:ciWorkflowContent | Should -Match 'ProvenanceContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'WorkspaceShaRefreshPrContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'WorkspaceManifestPinRefreshScript\.Tests\.ps1'
+        $script:ciWorkflowContent | Should -Match 'ENABLE_SELF_HOSTED_CONTRACTS'
     }
 
     It 'defines manual installer release workflow contract' {


### PR DESCRIPTION
## Summary
- dispatch ci.yml from workspace-sha-refresh-pr.yml after creating/updating utomation/sha-refresh PRs so required CI Pipeline checks appear on bot branches
- add ctions: write workflow permission needed for workflow dispatch
- make self-hosted contract lanes in ci.yml opt-in with ENABLE_SELF_HOSTED_CONTRACTS=true so repos without self-hosted runners do not queue indefinitely
- update AGENTS/README and contract tests for the new behavior

## Validation
- Invoke-Pester -Path .\\tests -CI
