### PR TITLE
Fix self-hosted deterministic bundle invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) {
             throw "Build-RunnerCliBundleFromManifest.ps1 failed with exit code $LASTEXITCODE"
           }
@@ -118,7 +118,7 @@ jobs:
             throw "makensis version probe failed with exit code $LASTEXITCODE"
           }
 
-          & $buildScript -PayloadRoot $payloadRoot -OutputPath $assetPath -WorkspaceRootDefault 'C:\dev' -NsisRoot $nsisRoot -Deterministic $true
+          & $buildScript -PayloadRoot $payloadRoot -OutputPath $assetPath -WorkspaceRootDefault 'C:\dev' -NsisRoot $nsisRoot -Deterministic:$true
           if ($LASTEXITCODE -ne 0) {
             throw "Build-WorkspaceBootstrapInstaller.ps1 failed with exit code $LASTEXITCODE"
           }
@@ -164,12 +164,16 @@ jobs:
 
           Copy-Item -Path "$env:GITHUB_WORKSPACE/scripts/Install-WorkspaceFromManifest.ps1" -Destination (Join-Path $payloadRoot 'scripts/Install-WorkspaceFromManifest.ps1') -Force
 
-          & pwsh -NoProfile -File (Join-Path $env:GITHUB_WORKSPACE 'scripts/Build-RunnerCliBundleFromManifest.ps1') `
+          $bundleRunnerCliScript = Join-Path $env:GITHUB_WORKSPACE 'scripts/Build-RunnerCliBundleFromManifest.ps1'
+          if (-not (Test-Path -LiteralPath $bundleRunnerCliScript -PathType Leaf)) {
+            throw "Runner CLI bundle script not found: $bundleRunnerCliScript"
+          }
+          & $bundleRunnerCliScript `
             -ManifestPath (Join-Path $payloadRoot 'workspace-governance/workspace-governance.json') `
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to build deterministic runner-cli payload bundle."
           }
@@ -245,12 +249,16 @@ jobs:
 
           Copy-Item -Path "$env:GITHUB_WORKSPACE/scripts/Install-WorkspaceFromManifest.ps1" -Destination (Join-Path $payloadRoot 'scripts/Install-WorkspaceFromManifest.ps1') -Force
 
-          & pwsh -NoProfile -File (Join-Path $env:GITHUB_WORKSPACE 'scripts/Build-RunnerCliBundleFromManifest.ps1') `
+          $bundleRunnerCliScript = Join-Path $env:GITHUB_WORKSPACE 'scripts/Build-RunnerCliBundleFromManifest.ps1'
+          if (-not (Test-Path -LiteralPath $bundleRunnerCliScript -PathType Leaf)) {
+            throw "Runner CLI bundle script not found: $bundleRunnerCliScript"
+          }
+          & $bundleRunnerCliScript `
             -ManifestPath (Join-Path $payloadRoot 'workspace-governance/workspace-governance.json') `
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) { throw 'Failed to build runner-cli bundle.' }
 
           $installerPath = Join-Path $env:RUNNER_TEMP 'lvie-cdev-workspace-installer.exe'
@@ -263,7 +271,7 @@ jobs:
             -OutputPath $installerPath `
             -WorkspaceRootDefault 'C:\dev' `
             -NsisRoot $nsisRoot `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) { throw 'Failed to build workspace installer for provenance.' }
 
           $provRoot = Join-Path $env:RUNNER_TEMP 'provenance'

--- a/.github/workflows/nightly-supplychain-canary.yml
+++ b/.github/workflows/nightly-supplychain-canary.yml
@@ -63,12 +63,16 @@ jobs:
 
           Copy-Item -Path "$env:GITHUB_WORKSPACE/scripts/Install-WorkspaceFromManifest.ps1" -Destination (Join-Path $payloadRoot 'scripts/Install-WorkspaceFromManifest.ps1') -Force
 
-          & pwsh -NoProfile -File "$env:GITHUB_WORKSPACE/scripts/Build-RunnerCliBundleFromManifest.ps1" `
+          $bundleRunnerCliScript = Join-Path $env:GITHUB_WORKSPACE 'scripts/Build-RunnerCliBundleFromManifest.ps1'
+          if (-not (Test-Path -LiteralPath $bundleRunnerCliScript -PathType Leaf)) {
+            throw "Runner CLI bundle script not found: $bundleRunnerCliScript"
+          }
+          & $bundleRunnerCliScript `
             -ManifestPath (Join-Path $payloadRoot 'workspace-governance/workspace-governance.json') `
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) { throw 'Failed to build runner-cli payload for installer determinism canary.' }
 
           $nsisRoot = '${{ vars.NSIS_ROOT }}'

--- a/.github/workflows/release-workspace-installer.yml
+++ b/.github/workflows/release-workspace-installer.yml
@@ -55,12 +55,16 @@ jobs:
 
           Copy-Item -Path "$env:GITHUB_WORKSPACE/scripts/Install-WorkspaceFromManifest.ps1" -Destination (Join-Path $payloadRoot 'scripts/Install-WorkspaceFromManifest.ps1') -Force
 
-          & pwsh -NoProfile -File (Join-Path $env:GITHUB_WORKSPACE 'scripts/Build-RunnerCliBundleFromManifest.ps1') `
+          $bundleRunnerCliScript = Join-Path $env:GITHUB_WORKSPACE 'scripts/Build-RunnerCliBundleFromManifest.ps1'
+          if (-not (Test-Path -LiteralPath $bundleRunnerCliScript -PathType Leaf)) {
+            throw "Runner CLI bundle script not found: $bundleRunnerCliScript"
+          }
+          & $bundleRunnerCliScript `
             -ManifestPath (Join-Path $payloadRoot 'workspace-governance/workspace-governance.json') `
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) { throw "Build-RunnerCliBundleFromManifest.ps1 failed." }
 
           & pwsh -NoProfile -File (Join-Path $env:GITHUB_WORKSPACE 'scripts/Test-RunnerCliBundleDeterminism.ps1') `


### PR DESCRIPTION
## Summary
- replace nested pwsh -File invocations for Build-RunnerCliBundleFromManifest.ps1 with direct script invocation in CI/release/nightly workflows
- pass deterministic flag as -Deterministic:True to avoid bool transformation issues in self-hosted runs
- add explicit script existence checks before invocation

## Validation
- Invoke-Pester -Path .\\tests -CI
