### PR TITLE
Align manifest policy with branch protection required checks

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -293,7 +293,10 @@
       "branch_protection_required": true,
       "default_branch_mutation_policy": "block_when_contract_missing",
       "required_status_checks": [
-        "CI Pipeline"
+        "CI Pipeline",
+        "Workspace Installer Contract",
+        "Reproducibility Contract",
+        "Provenance Contract"
       ],
       "strict_status_checks": true,
       "required_review_policy": {
@@ -323,7 +326,10 @@
       "branch_protection_required": true,
       "default_branch_mutation_policy": "block_when_contract_missing",
       "required_status_checks": [
-        "CI Pipeline"
+        "CI Pipeline",
+        "Workspace Installer Contract",
+        "Reproducibility Contract",
+        "Provenance Contract"
       ],
       "strict_status_checks": true,
       "required_review_policy": {

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -293,7 +293,10 @@
       "branch_protection_required": true,
       "default_branch_mutation_policy": "block_when_contract_missing",
       "required_status_checks": [
-        "CI Pipeline"
+        "CI Pipeline",
+        "Workspace Installer Contract",
+        "Reproducibility Contract",
+        "Provenance Contract"
       ],
       "strict_status_checks": true,
       "required_review_policy": {
@@ -323,7 +326,10 @@
       "branch_protection_required": true,
       "default_branch_mutation_policy": "block_when_contract_missing",
       "required_status_checks": [
-        "CI Pipeline"
+        "CI Pipeline",
+        "Workspace Installer Contract",
+        "Reproducibility Contract",
+        "Provenance Contract"
       ],
       "strict_status_checks": true,
       "required_review_policy": {


### PR DESCRIPTION
## Summary
- update cdev-surface and cdev-surface-upstream equired_status_checks in workspace-governance.json
- mirror the same change in the canonical payload manifest
- keep policy contract in parity with enforced branch protection contexts

## Validation
- Invoke-Pester -Path .\\tests -CI
- pwsh -NoProfile -File C:\\dev\\scripts\\Test-PolicyContracts.ps1 -WorkspaceRoot C:\\dev -FailOnWarning
