### PR TITLE
fix: isolate self-hosted temp paths and require refresh bot token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             './tests/WorkspaceInstallRuntimeContract.Tests.ps1',
             './tests/Build-WorkspaceBootstrapInstaller.Tests.ps1',
             './tests/Build-RunnerCliBundleFromManifest.Tests.ps1',
+            './tests/BuildRunnerCliBundleTempIsolationContract.Tests.ps1',
             './tests/RunnerCliBundleDeterminismContract.Tests.ps1',
             './tests/WorkspaceInstallerDeterminismContract.Tests.ps1',
             './tests/ProvenanceContract.Tests.ps1',

--- a/.github/workflows/workspace-sha-refresh-pr.yml
+++ b/.github/workflows/workspace-sha-refresh-pr.yml
@@ -21,11 +21,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate workflow bot token
+        shell: pwsh
+        env:
+          WORKFLOW_BOT_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:WORKFLOW_BOT_TOKEN)) {
+            throw "Required secret WORKFLOW_BOT_TOKEN is not configured. Add a token with contents:write, pull-requests:write, and workflow dispatch capability."
+          }
+
       - id: refresh
         name: Update manifest pinned SHAs
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
         run: |
           $ErrorActionPreference = 'Stop'
           $reportPath = Join-Path $env:RUNNER_TEMP 'workspace-sha-refresh-report.json'
@@ -77,7 +87,7 @@ jobs:
         if: steps.refresh.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.WORKFLOW_BOT_TOKEN }}
           commit-message: 'chore(manifest): refresh pinned SHAs'
           branch: automation/sha-refresh
           delete-branch: true
@@ -100,7 +110,7 @@ jobs:
         if: steps.create_pr.outputs.pull-request-number != ''
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
         run: |
           $ErrorActionPreference = 'Stop'
           & gh workflow run ci.yml `
@@ -114,7 +124,7 @@ jobs:
         if: steps.create_pr.outputs.pull-request-number != ''
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
         run: |
           $ErrorActionPreference = 'Stop'
           & gh pr merge "${{ steps.create_pr.outputs.pull-request-number }}" `

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,13 @@ This repository is the canonical policy and manifest surface for deterministic `
 ## Release Signal Contract
 - `Workspace SHA Refresh PR` is the primary path for updating `pinned_sha` values.
 - On drift, automation must update manifest pins, create/update branch `automation/sha-refresh`, and open or update a PR to `main`.
+- `workspace-sha-refresh-pr.yml` requires repository secret `WORKFLOW_BOT_TOKEN` for branch mutation, PR operations, and workflow dispatch.
+- If `WORKFLOW_BOT_TOKEN` is missing or misconfigured, refresh automation must fail fast with explicit remediation.
 - Auto-merge is enabled by default for refresh PRs using squash strategy.
 - Maintainer review is not required for `labview-cdev-surface` refresh PR merges (`required_approving_review_count = 0`).
 - Do not bypass this by weakening checks or disabling scheduled runs.
-- If automation cannot create or merge the PR, manual refresh is fallback.
+- Do not use manual no-op pushes as a normal workaround for refresh PR check propagation.
+- If automation cannot create or merge the PR due to platform outage, manual refresh is fallback.
 
 ## Installer Release Contract
 - The NSIS workspace installer is published as a GitHub release asset from `.github/workflows/release-workspace-installer.yml`.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ This repository owns:
 Auto-refresh policy:
 1. Auto-merge is enabled by default for refresh PRs with squash strategy.
 2. Maintainer approval is not required for `labview-cdev-surface` refresh merges (`required_approving_review_count = 0`).
-3. Required status checks remain strict (`CI Pipeline`).
-4. If automation fails due to permissions or API errors, use manual fallback PR flow.
+3. Required status checks remain strict (`CI Pipeline`, `Workspace Installer Contract`, `Reproducibility Contract`, `Provenance Contract`).
+4. `workspace-sha-refresh-pr.yml` requires repository secret `WORKFLOW_BOT_TOKEN` for branch mutation, PR operations, and workflow dispatch.
+5. If `WORKFLOW_BOT_TOKEN` is missing or misconfigured, refresh automation fails fast with an explicit error.
+6. Manual refresh PR flow is fallback only for platform outages, not routine check propagation.
 
 ## Local checks
 

--- a/scripts/Build-RunnerCliBundleFromManifest.ps1
+++ b/scripts/Build-RunnerCliBundleFromManifest.ps1
@@ -38,6 +38,79 @@ function Convert-ToEpochIso8601 {
     return [DateTimeOffset]::FromUnixTimeSeconds($EpochSeconds).UtcDateTime.ToString('o')
 }
 
+function Convert-ToPathSafeSegment {
+    param(
+        [Parameter(Mandatory = $true)][string]$Value,
+        [Parameter()][int]$MaxLength = 64
+    )
+
+    $safe = $Value -replace '[^A-Za-z0-9._-]', '-'
+    $safe = $safe -replace '-{2,}', '-'
+    $safe = $safe.Trim('-')
+    if ([string]::IsNullOrWhiteSpace($safe)) {
+        $safe = 'segment'
+    }
+    if ($safe.Length -gt $MaxLength) {
+        $safe = $safe.Substring(0, $MaxLength)
+    }
+    return $safe
+}
+
+function Get-TempBasePath {
+    if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+        return [System.IO.Path]::GetFullPath($env:RUNNER_TEMP)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:TEMP)) {
+        return [System.IO.Path]::GetFullPath($env:TEMP)
+    }
+    throw "Neither RUNNER_TEMP nor TEMP is set. Cannot allocate temporary workspace."
+}
+
+function Get-IsolationToken {
+    $seed = [string]::Join(
+        '|',
+        @(
+            [string]$env:GITHUB_RUN_ID,
+            [string]$env:GITHUB_JOB,
+            [string]$env:RUNNER_NAME,
+            [string]$PID,
+            [guid]::NewGuid().ToString('N')
+        )
+    )
+
+    $hashAlgorithm = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($seed)
+        $hashBytes = $hashAlgorithm.ComputeHash($bytes)
+    } finally {
+        $hashAlgorithm.Dispose()
+    }
+
+    $hash = [System.BitConverter]::ToString($hashBytes).Replace('-', '').ToLowerInvariant()
+    return $hash.Substring(0, 12)
+}
+
+function Remove-Directory {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter()][switch]$BestEffort
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return
+    }
+
+    try {
+        Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
+    } catch {
+        if ($BestEffort) {
+            Write-Warning "Failed to remove temporary directory '$Path': $($_.Exception.Message)"
+            return
+        }
+        throw
+    }
+}
+
 function Get-PinnedSdkVersion {
     param([Parameter(Mandatory = $true)][string]$RepoRoot)
 
@@ -134,11 +207,19 @@ if ($pinnedSha -notmatch '^[0-9a-f]{40}$') {
 }
 
 $epoch = if ($PSBoundParameters.ContainsKey('SourceDateEpoch')) { $SourceDateEpoch } else { 0L }
-$tempRoot = Join-Path $env:TEMP ("lvie-runner-cli-bundle-{0}-{1}-{2}" -f $RepoName, $pinnedSha.Substring(0, 12), $Runtime)
+$tempBasePath = Get-TempBasePath
+Ensure-Directory -Path $tempBasePath
+$tempRoot = Join-Path $tempBasePath (
+    "lvie-runner-cli-bundle-{0}-{1}-{2}-{3}" -f
+    (Convert-ToPathSafeSegment -Value $RepoName -MaxLength 24),
+    $pinnedSha.Substring(0, 12),
+    (Convert-ToPathSafeSegment -Value $Runtime -MaxLength 24),
+    (Get-IsolationToken)
+)
 $cloneRoot = Join-Path $tempRoot 'src'
 $publishRoot = Join-Path $tempRoot 'publish'
 if (Test-Path -LiteralPath $tempRoot -PathType Container) {
-    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    Remove-Directory -Path $tempRoot
 }
 Ensure-Directory -Path $cloneRoot
 Ensure-Directory -Path $publishRoot
@@ -246,6 +327,6 @@ try {
     } | ConvertTo-Json -Depth 8 | Write-Output
 } finally {
     if (-not $KeepTemp -and (Test-Path -LiteralPath $tempRoot -PathType Container)) {
-        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+        Remove-Directory -Path $tempRoot -BestEffort
     }
 }

--- a/tests/Build-RunnerCliBundleFromManifest.Tests.ps1
+++ b/tests/Build-RunnerCliBundleFromManifest.Tests.ps1
@@ -24,6 +24,14 @@ Describe 'Build runner-cli bundle from manifest contract' {
         $script:scriptContent | Should -Match 'global\.json'
     }
 
+    It 'uses runner temp with fallback and isolated temp roots' {
+        $script:scriptContent | Should -Match '\$env:RUNNER_TEMP'
+        $script:scriptContent | Should -Match '\$env:TEMP'
+        $script:scriptContent | Should -Match 'Get-IsolationToken'
+        $script:scriptContent | Should -Match 'lvie-runner-cli-bundle-'
+        $script:scriptContent | Should -Match 'Write-Warning'
+    }
+
     It 'builds and writes runner-cli executable, hash, and metadata' {
         $script:scriptContent | Should -Match 'dotnet publish'
         $script:scriptContent | Should -Match 'runner-cli\.exe'

--- a/tests/BuildRunnerCliBundleTempIsolationContract.Tests.ps1
+++ b/tests/BuildRunnerCliBundleTempIsolationContract.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Build runner-cli temp isolation contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:scriptPath = Join-Path $script:repoRoot 'scripts/Build-RunnerCliBundleFromManifest.ps1'
+        if (-not (Test-Path -LiteralPath $script:scriptPath -PathType Leaf)) {
+            throw "Runner CLI bundle script missing: $script:scriptPath"
+        }
+
+        $script:scriptContent = Get-Content -LiteralPath $script:scriptPath -Raw
+    }
+
+    It 'prefers RUNNER_TEMP and falls back to TEMP' {
+        $script:scriptContent | Should -Match 'function Get-TempBasePath'
+        $script:scriptContent | Should -Match '\$env:RUNNER_TEMP'
+        $script:scriptContent | Should -Match '\$env:TEMP'
+        $script:scriptContent | Should -Match 'Neither RUNNER_TEMP nor TEMP is set'
+    }
+
+    It 'builds per-invocation isolated temp roots' {
+        $script:scriptContent | Should -Match 'function Get-IsolationToken'
+        $script:scriptContent | Should -Match '\$env:GITHUB_RUN_ID'
+        $script:scriptContent | Should -Match '\$env:GITHUB_JOB'
+        $script:scriptContent | Should -Match '\$env:RUNNER_NAME'
+        $script:scriptContent | Should -Match '\[guid\]::NewGuid'
+        $script:scriptContent | Should -Match 'lvie-runner-cli-bundle-'
+    }
+
+    It 'uses best-effort cleanup in finally' {
+        $script:scriptContent | Should -Match 'function Remove-Directory'
+        $script:scriptContent | Should -Match '\[switch\]\$BestEffort'
+        $script:scriptContent | Should -Match 'Write-Warning'
+        $script:scriptContent | Should -Match 'Remove-Directory -Path \$tempRoot -BestEffort'
+    }
+
+    It 'has parse-safe PowerShell syntax' {
+        $tokens = $null
+        $errors = $null
+        [void][System.Management.Automation.Language.Parser]::ParseInput($script:scriptContent, [ref]$tokens, [ref]$errors)
+        @($errors).Count | Should -Be 0
+    }
+}

--- a/tests/WorkspaceShaRefreshPrContract.Tests.ps1
+++ b/tests/WorkspaceShaRefreshPrContract.Tests.ps1
@@ -29,6 +29,13 @@ Describe 'Workspace SHA refresh PR workflow contract' {
         $script:workflowContent | Should -Match 'workspace-governance-payload/workspace-governance/workspace-governance\.json'
     }
 
+    It 'requires WORKFLOW_BOT_TOKEN for mutation operations' {
+        $script:workflowContent | Should -Match 'WORKFLOW_BOT_TOKEN'
+        $script:workflowContent | Should -Match 'Required secret WORKFLOW_BOT_TOKEN is not configured'
+        $script:workflowContent | Should -Match 'token:\s*\${{\s*secrets\.WORKFLOW_BOT_TOKEN\s*}}'
+        $script:workflowContent | Should -Not -Match 'token:\s*\${{\s*github\.token\s*}}'
+    }
+
     It 'enables squash auto-merge for refresh PRs' {
         $script:workflowContent | Should -Match 'gh pr merge'
         $script:workflowContent | Should -Match '--auto'


### PR DESCRIPTION
## Summary
- isolate runner-cli bundle temp paths per invocation to prevent self-hosted collision across concurrent jobs
- prefer RUNNER_TEMP with TEMP fallback and retain deterministic PathMap semantics
- make temp cleanup best-effort in finally to avoid post-success hard failures
- require WORKFLOW_BOT_TOKEN in workspace SHA refresh workflow and use it for PR/workflow/auto-merge operations
- add/update contract tests and docs for the new temp-isolation and bot-token requirements

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester -Path .\tests -CI"`
- `pwsh -NoProfile -File .\scripts\Test-PolicyContracts.ps1 -WorkspaceRoot C:\dev -FailOnWarning`
