### PR TITLE
fix: stabilize temp isolation token for reproducibility

### DIFF
--- a/tests/BuildRunnerCliBundleTempIsolationContract.Tests.ps1
+++ b/tests/BuildRunnerCliBundleTempIsolationContract.Tests.ps1
@@ -24,9 +24,10 @@ Describe 'Build runner-cli temp isolation contract' {
     It 'builds per-invocation isolated temp roots' {
         $script:scriptContent | Should -Match 'function Get-IsolationToken'
         $script:scriptContent | Should -Match '\$env:GITHUB_RUN_ID'
+        $script:scriptContent | Should -Match '\$env:GITHUB_RUN_ATTEMPT'
         $script:scriptContent | Should -Match '\$env:GITHUB_JOB'
         $script:scriptContent | Should -Match '\$env:RUNNER_NAME'
-        $script:scriptContent | Should -Match '\[guid\]::NewGuid'
+        $script:scriptContent | Should -Match "\$seedParts = @\('local'\)"
         $script:scriptContent | Should -Match 'lvie-runner-cli-bundle-'
     }
 


### PR DESCRIPTION
## Summary
- keep temp isolation stable per run/job by removing per-invocation GUID/PID entropy
- preserve collision isolation across concurrent jobs via run/job/attempt/runner token seed
- keep deterministic runner-cli builds path-stable within a job so reproducibility hash comparisons remain valid
- update temp-isolation contract test accordingly

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester -Path .\tests -CI"`
