### PR TITLE
fix: re-enable release workflow dispatch

### DIFF
--- a/.github/workflows/release-workspace-installer.yml
+++ b/.github/workflows/release-workspace-installer.yml
@@ -191,23 +191,23 @@ jobs:
           }
 
           $releaseNotesPath = Join-Path $env:RUNNER_TEMP "release-notes-$releaseTag.md"
-          $releaseNotes = @"
-# Workspace Installer $releaseTag
-
-Release assets:
-- $assetName
-- $(Split-Path -Path $shaPath -Leaf)
-- $(Split-Path -Path $reproPath -Leaf)
-- $(Split-Path -Path $spdxPath -Leaf)
-- $(Split-Path -Path $slsaPath -Leaf)
-
-SHA256:
-- $assetSha
-
-Install command:
-$installCommand
-"@
-          $releaseNotes | Set-Content -LiteralPath $releaseNotesPath -Encoding utf8
+          $releaseNoteLines = @(
+            "# Workspace Installer $releaseTag"
+            ""
+            "Release assets:"
+            "- $assetName"
+            "- $(Split-Path -Path $shaPath -Leaf)"
+            "- $(Split-Path -Path $reproPath -Leaf)"
+            "- $(Split-Path -Path $spdxPath -Leaf)"
+            "- $(Split-Path -Path $slsaPath -Leaf)"
+            ""
+            "SHA256:"
+            "- $assetSha"
+            ""
+            "Install command:"
+            $installCommand
+          )
+          $releaseNoteLines | Set-Content -LiteralPath $releaseNotesPath -Encoding utf8
 
           $repo = [string]$env:TARGET_REPOSITORY
           $prerelease = $false


### PR DESCRIPTION
## Summary
- fix invalid YAML in `release-workspace-installer.yml` by restoring proper indentation inside the publish-step run block
- keep parser-safe release-notes construction and `gh release create/edit` invocation behavior

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester -Path .\tests\WorkspaceInstallerReleaseContract.Tests.ps1,.\tests\WorkspaceSurfaceContract.Tests.ps1 -CI"`
