### PR TITLE
chore(manifest): pin icon-editor entries to upstream 893e8bb

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -90,7 +90,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
+      "pinned_sha": "893e8bb8784eccdb28c40b2a4490f621eca68c4d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -123,7 +123,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
+      "pinned_sha": "893e8bb8784eccdb28c40b2a4490f621eca68c4d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -154,7 +154,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
+      "pinned_sha": "893e8bb8784eccdb28c40b2a4490f621eca68c4d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -90,7 +90,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
+      "pinned_sha": "893e8bb8784eccdb28c40b2a4490f621eca68c4d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -123,7 +123,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
+      "pinned_sha": "893e8bb8784eccdb28c40b2a4490f621eca68c4d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -154,7 +154,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
+      "pinned_sha": "893e8bb8784eccdb28c40b2a4490f621eca68c4d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",


### PR DESCRIPTION
## Summary
- update icon-editor pinned SHA values in both governance manifests
- align `labview-icon-editor`, `labview-icon-editor-org`, and `labview-icon-editor-upstream` to upstream commit `893e8bb8784eccdb28c40b2a4490f621eca68c4d`

## Validation
- `pwsh -NoProfile -File .\\scripts\\Test-PolicyContracts.ps1 -WorkspaceRoot C:\\dev -FailOnWarning`
- `Invoke-Pester -CI -Path .\\tests\\WorkspaceSurfaceContract.Tests.ps1,.\\tests\\WorkspaceManifestPinRefreshScript.Tests.ps1`