### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "fb5e6cbdd851ea0cb2c272dd0d3dd77bb7fea988"
+      "pinned_sha": "304c09dae341c0709d4f69d9bc29aea97ef3fb6d"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -352,7 +352,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "0f5b2c8213405c2ae2a4398c95315f540937c8ef"
+      "pinned_sha": "304c09dae341c0709d4f69d9bc29aea97ef3fb6d"
     }
   ]
 }

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "fb5e6cbdd851ea0cb2c272dd0d3dd77bb7fea988"
+      "pinned_sha": "304c09dae341c0709d4f69d9bc29aea97ef3fb6d"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -352,7 +352,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "0f5b2c8213405c2ae2a4398c95315f540937c8ef"
+      "pinned_sha": "304c09dae341c0709d4f69d9bc29aea97ef3fb6d"
     }
   ]
 }


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 2
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/LabVIEW-Community-CI-CD/labview-cdev-surface/actions/runs/22319074972
- Merge strategy: squash auto-merge