### PR TITLE
fix(drift): accept self-repo first-parent pin semantics

### DIFF
--- a/scripts/Test-WorkspaceManifestBranchDrift.ps1
+++ b/scripts/Test-WorkspaceManifestBranchDrift.ps1
@@ -5,7 +5,10 @@ param(
     [string]$ManifestPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'workspace-governance.json'),
 
     [Parameter()]
-    [string]$OutputPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'artifacts\workspace-drift\workspace-drift-report.json')
+    [string]$OutputPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'artifacts\workspace-drift\workspace-drift-report.json'),
+
+    [Parameter()]
+    [string]$SelfRepoSlug = ''
 )
 
 Set-StrictMode -Version Latest
@@ -26,6 +29,40 @@ function Initialize-GhToken {
     return ''
 }
 $tokenSource = Initialize-GhToken
+
+function Resolve-SelfRepoSlug {
+    param(
+        [Parameter()]
+        [string]$SelfRepoSlugOverride
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($SelfRepoSlugOverride)) {
+        return $SelfRepoSlugOverride
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_REPOSITORY)) {
+        return [string]$env:GITHUB_REPOSITORY
+    }
+    return ''
+}
+
+function Get-CommitFirstParentSha {
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepoSlug,
+        [Parameter(Mandatory)]
+        [string]$CommitSha
+    )
+
+    $encodedCommit = [System.Uri]::EscapeDataString($CommitSha)
+    $parentOutput = & gh api "repos/$RepoSlug/commits/$encodedCommit" --jq '.parents[0].sha' 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        return ''
+    }
+
+    return ([string]$parentOutput).Trim().ToLowerInvariant()
+}
+
+$resolvedSelfRepoSlug = Resolve-SelfRepoSlug -SelfRepoSlugOverride $SelfRepoSlug
 
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw "Required command 'gh' was not found on PATH."
@@ -54,6 +91,7 @@ foreach ($repo in @($manifest.managed_repos)) {
         default_branch = $defaultBranch
         pinned_sha = $pinnedSha
         actual_default_branch_sha = ''
+        actual_default_branch_parent_sha = ''
         status = 'unknown'
         message = ''
     }
@@ -82,9 +120,20 @@ foreach ($repo in @($manifest.managed_repos)) {
         $check.status = 'in_sync'
         $check.message = 'Default branch SHA matches manifest pin.'
     } else {
-        $check.status = 'drifted'
-        $check.message = 'Default branch SHA differs from manifest pin.'
-        $drifts += "{0}:{1}" -f $repoSlug, $defaultBranch
+        $parentSha = ''
+        if (-not [string]::IsNullOrWhiteSpace($resolvedSelfRepoSlug) -and $repoSlug -eq $resolvedSelfRepoSlug) {
+            $parentSha = Get-CommitFirstParentSha -RepoSlug $repoSlug -CommitSha $actualSha
+            $check.actual_default_branch_parent_sha = $parentSha
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($parentSha) -and $parentSha -eq $pinnedSha) {
+            $check.status = 'in_sync_self_parent'
+            $check.message = 'Default branch head advanced; manifest pin matches first parent for self-repo merge semantics.'
+        } else {
+            $check.status = 'drifted'
+            $check.message = 'Default branch SHA differs from manifest pin.'
+            $drifts += "{0}:{1}" -f $repoSlug, $defaultBranch
+        }
     }
 
     $checks += [pscustomobject]$check

--- a/tests/WorkspaceShaDriftSignalContract.Tests.ps1
+++ b/tests/WorkspaceShaDriftSignalContract.Tests.ps1
@@ -37,6 +37,13 @@ Describe 'Workspace SHA drift signal contract' {
         $script:scriptContent | Should -Match '--jq ''\.sha'''
     }
 
+    It 'supports self-repo first-parent pin semantics to avoid recursive drift loops' {
+        $script:scriptContent | Should -Match 'GITHUB_REPOSITORY'
+        $script:scriptContent | Should -Match 'parents\[0\]\.sha'
+        $script:scriptContent | Should -Match 'in_sync_self_parent'
+        $script:scriptContent | Should -Match 'actual_default_branch_parent_sha'
+    }
+
     It 'uses workflow bot token strategy for cross-repo drift lookup' {
         $script:workflowContent | Should -Match 'WORKFLOW_BOT_TOKEN:\s*\$\{\{\s*secrets\.WORKFLOW_BOT_TOKEN\s*\}\}'
         $script:workflowContent | Should -Match 'GH_TOKEN:\s*\$\{\{\s*secrets\.WORKFLOW_BOT_TOKEN\s*\}\}'


### PR DESCRIPTION
## Summary
- fix recursive drift loop for the surface repo's own upstream entry
- when evaluating the self repo slug, treat `pinned_sha == head^1` as in-sync (`in_sync_self_parent`)
- keep true drift detection for all other repos and for self-repo entries that are not immediate post-merge parent-aligned
- add contract coverage for self-repo parent semantics

## Why
After auto-refresh PR merge, `main` advances to a new commit that cannot pin itself in the same commit. This caused deterministic false drift on `LabVIEW-Community-CI-CD/labview-cdev-surface` every cycle.

## Validation
- `Invoke-Pester -CI -Path .\\tests\\WorkspaceShaDriftSignalContract.Tests.ps1,.\\tests\\WorkspaceSurfaceContract.Tests.ps1`