### PR TITLE
fix(release): enforce immutable tags by default

### DIFF
--- a/.github/workflows/release-workspace-installer.yml
+++ b/.github/workflows/release-workspace-installer.yml
@@ -7,6 +7,11 @@ on:
         description: Release tag to publish (for example, v0.1.0).
         required: true
         type: string
+      allow_existing_tag:
+        description: Allow updating an existing release tag (break-glass only).
+        required: false
+        default: false
+        type: boolean
       prerelease:
         description: Publish as prerelease.
         required: false
@@ -201,7 +206,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPOSITORY: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          ALLOW_EXISTING_TAG: ${{ inputs.allow_existing_tag }}
           PRERELEASE: ${{ inputs.prerelease }}
+          RELEASE_TARGET_SHA: ${{ github.sha }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -236,6 +243,9 @@ jobs:
           $releaseNoteLines = @(
             "# Workspace Installer $releaseTag"
             ""
+            "Release target commit:"
+            "- $env:RELEASE_TARGET_SHA"
+            ""
             "Release assets:"
             "- $assetName"
             "- $(Split-Path -Path $shaPath -Leaf)"
@@ -252,20 +262,40 @@ jobs:
           $releaseNoteLines | Set-Content -LiteralPath $releaseNotesPath -Encoding utf8
 
           $repo = [string]$env:TARGET_REPOSITORY
+          $allowExistingTag = $false
+          if (-not [string]::IsNullOrWhiteSpace($env:ALLOW_EXISTING_TAG)) {
+            $allowExistingTag = [System.Convert]::ToBoolean($env:ALLOW_EXISTING_TAG)
+          }
           $prerelease = $false
           if (-not [string]::IsNullOrWhiteSpace($env:PRERELEASE)) {
             $prerelease = [System.Convert]::ToBoolean($env:PRERELEASE)
           }
+          $releaseTargetSha = ([string]$env:RELEASE_TARGET_SHA).Trim().ToLowerInvariant()
+          if ($releaseTargetSha -notmatch '^[0-9a-f]{40}$') {
+            throw "Invalid release target SHA '$releaseTargetSha'."
+          }
 
-          & gh release view $releaseTag -R $repo *> $null
-          $releaseExists = ($LASTEXITCODE -eq 0)
+          $releaseExists = $false
+          $existingReleaseMetadata = $null
+          $releaseViewOutput = & gh release view $releaseTag -R $repo --json tagName,publishedAt,url 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            $releaseExists = $true
+            $existingReleaseMetadata = $releaseViewOutput | ConvertFrom-Json -ErrorAction Stop
+          }
+
+          if ($releaseExists -and -not $allowExistingTag) {
+            $publishedAt = [string]$existingReleaseMetadata.publishedAt
+            $releaseUrl = [string]$existingReleaseMetadata.url
+            throw "Release tag '$releaseTag' already exists (publishedAt=$publishedAt, url=$releaseUrl). Use a new semantic tag or set allow_existing_tag=true for break-glass overwrite."
+          }
+
           $releaseTitle = "Workspace Installer $releaseTag"
 
           if (-not $releaseExists) {
             if ($prerelease) {
-              & gh release create $releaseTag -R $repo --title $releaseTitle --notes-file $releaseNotesPath --prerelease
+              & gh release create $releaseTag -R $repo --target $releaseTargetSha --title $releaseTitle --notes-file $releaseNotesPath --prerelease
             } else {
-              & gh release create $releaseTag -R $repo --title $releaseTitle --notes-file $releaseNotesPath
+              & gh release create $releaseTag -R $repo --target $releaseTargetSha --title $releaseTitle --notes-file $releaseNotesPath
             }
             if ($LASTEXITCODE -ne 0) { throw "Failed to create release '$releaseTag' for '$repo'." }
           } else {
@@ -277,7 +307,11 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "Failed to edit release '$releaseTag' for '$repo'." }
           }
 
-          & gh release upload $releaseTag $assetPath $shaPath $reproPath $spdxPath $slsaPath -R $repo --clobber
+          if ($allowExistingTag) {
+            & gh release upload $releaseTag $assetPath $shaPath $reproPath $spdxPath $slsaPath -R $repo --clobber
+          } else {
+            & gh release upload $releaseTag $assetPath $shaPath $reproPath $spdxPath $slsaPath -R $repo
+          }
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to upload release assets for '$releaseTag'."
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ This repository is the canonical policy and manifest surface for deterministic `
 ## Installer Release Contract
 - The NSIS workspace installer is published as a GitHub release asset from `.github/workflows/release-workspace-installer.yml`.
 - Publishing mode is manual dispatch only with explicit semantic tag input (`v<major>.<minor>.<patch>`).
+- Release tags are immutable by default: existing tags must fail publication unless `allow_existing_tag=true` is explicitly set for break-glass recovery.
+- Release creation must bind tag creation to the exact workflow commit SHA (`github.sha`), not a moving branch target.
 - Keep fork-first mutation rules when preparing release changes:
   - mutate `origin` (`svelderrainruiz/labview-cdev-surface`) only
   - open PRs to `LabVIEW-Community-CI-CD/labview-cdev-surface:main`

--- a/README.md
+++ b/README.md
@@ -124,15 +124,16 @@ If Docker Desktop cannot start, verify Windows virtualization features are enabl
 
 Use manual workflow dispatch for release publication:
 1. Run `.github/workflows/release-workspace-installer.yml`.
-2. Provide `release_tag` in semantic format (for example, `v0.1.0`).
-3. Set `prerelease` as needed.
+2. Provide a new `release_tag` in semantic format (for example, `v0.1.1`).
+3. Keep `allow_existing_tag=false` (default). Set `true` only for break-glass overwrite operations.
+4. Set `prerelease` as needed.
 
 The workflow:
 - Builds `lvie-cdev-workspace-installer.exe`
 - Computes SHA256
 - Runs determinism gates and fails on hash drift
 - Generates `workspace-installer.spdx.json` and `workspace-installer.slsa.json`
-- Creates the GitHub release if missing
+- Creates the GitHub release if missing and binds the tag to the exact workflow commit SHA
 - Uploads installer + SHA + provenance + reproducibility report assets to the release
 - Writes release notes including SHA256 and the install command:
 
@@ -141,6 +142,7 @@ lvie-cdev-workspace-installer.exe /S
 ```
 
 Verify downloaded asset integrity by matching the local hash against the SHA256 value published in the release notes.
+Tag immutability policy: existing release tags fail by default to prevent mutable release history.
 
 ## Nightly canary
 

--- a/tests/WorkspaceInstallerReleaseContract.Tests.ps1
+++ b/tests/WorkspaceInstallerReleaseContract.Tests.ps1
@@ -23,6 +23,8 @@ Describe 'Workspace installer release workflow contract' {
         $script:workflowContent | Should -Match 'type:\s*string'
         $script:workflowContent | Should -Match 'prerelease:'
         $script:workflowContent | Should -Match 'type:\s*boolean'
+        $script:workflowContent | Should -Match 'allow_existing_tag:'
+        $script:workflowContent | Should -Match 'Allow updating an existing release tag'
     }
 
     It 'defines package and publish jobs with release asset upload' {
@@ -38,6 +40,10 @@ Describe 'Workspace installer release workflow contract' {
         $script:workflowContent | Should -Match 'Test-ProvenanceContracts\.ps1'
         $script:workflowContent | Should -Match 'workspace-installer-release-\$\{\{\s*github\.run_id\s*\}\}'
         $script:workflowContent | Should -Match '(gh release create|''release'',\s*''create'')'
+        $script:workflowContent | Should -Match '--target \$releaseTargetSha'
+        $script:workflowContent | Should -Match 'RELEASE_TARGET_SHA:\s*\$\{\{\s*github\.sha\s*\}\}'
+        $script:workflowContent | Should -Match 'already exists'
+        $script:workflowContent | Should -Match 'allow_existing_tag=true'
         $script:workflowContent | Should -Match 'gh release upload'
         $script:workflowContent | Should -Match '--clobber'
     }
@@ -45,6 +51,7 @@ Describe 'Workspace installer release workflow contract' {
     It 'enforces release notes and tag validation' {
         $script:workflowContent | Should -Match '\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$'
         $script:workflowContent | Should -Match 'SHA256'
+        $script:workflowContent | Should -Match 'Release target commit'
         $script:workflowContent | Should -Match 'lvie-cdev-workspace-installer\.exe /S'
         $script:workflowContent | Should -Match 'workspace-installer\.spdx\.json'
         $script:workflowContent | Should -Match 'workspace-installer\.slsa\.json'


### PR DESCRIPTION
## Summary
- enforce immutable release-tag behavior by default in `release-workspace-installer.yml`
- add manual dispatch input `allow_existing_tag` (default `false`) for break-glass tag overwrite cases
- fail publication when `release_tag` already exists and override is not explicitly enabled
- bind new release tag creation to immutable workflow commit SHA (`github.sha`) via `gh release create --target`
- keep overwrite (`--clobber`) only for explicit break-glass path
- update release workflow contract tests and policy docs (README + AGENTS)

## Validation
- `Invoke-Pester -CI -Path .\\tests\\WorkspaceInstallerReleaseContract.Tests.ps1,.\\tests\\WorkspaceSurfaceContract.Tests.ps1`