### PR TITLE
fix(gate): pass deterministic bool args correctly

### DIFF
--- a/.github/workflows/_windows-labview-image-gate-core.yml
+++ b/.github/workflows/_windows-labview-image-gate-core.yml
@@ -54,7 +54,7 @@ jobs:
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to build runner-cli bundle for windows image gate."
           }
@@ -67,7 +67,7 @@ jobs:
             -OutputPath $installerPath `
             -WorkspaceRootDefault 'C:\dev' `
             -NsisRoot $nsisRoot `
-            -Deterministic $true
+            -Deterministic:$true
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to build installer for windows image gate."
           }


### PR DESCRIPTION
## Summary
- fix PowerShell bool argument passing in `_windows-labview-image-gate-core.yml`
- replace `-Deterministic $true` with `-Deterministic:$true`
- resolves upstream run failure in `windows-labview-image-gate` (`Cannot convert value "System.String" to type "System.Boolean"`)

## Validation
- `Invoke-Pester -Path @('./tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1','./tests/ReleaseWithWindowsGateWorkflowContract.Tests.ps1','./tests/WorkspaceSurfaceContract.Tests.ps1') -CI`
- Result: 13 passed, 0 failed