### PR TITLE
fix(gate): make windows container mode non-interactive

### DIFF
--- a/.github/workflows/_windows-labview-image-gate-core.yml
+++ b/.github/workflows/_windows-labview-image-gate-core.yml
@@ -72,12 +72,17 @@ jobs:
             throw "Failed to build installer for windows image gate."
           }
 
-      - name: Switch to Windows containers and pull image
+      - name: Validate Windows container engine and pull image
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          & 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchWindowsEngine
-          if ($LASTEXITCODE -ne 0) { throw 'Failed to switch Docker to Windows engine.' }
+          $serverOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim().ToLowerInvariant()
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($serverOs)) {
+            throw 'Failed to query Docker server OS. Ensure Docker Desktop is running and accessible from the runner service account.'
+          }
+          if ($serverOs -ne 'windows') {
+            throw "Docker server OS is '$serverOs'. Runner must be preconfigured for Windows containers; automatic engine switching is disabled for non-interactive CI."
+          }
           docker pull nationalinstruments/labview:latest-windows
           if ($LASTEXITCODE -ne 0) { throw 'Failed to pull LabVIEW Windows image.' }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ This repository is the canonical policy and manifest surface for deterministic `
 - Primary release publish path is `.github/workflows/release-with-windows-gate.yml`.
 - `release-with-windows-gate.yml` must run `repo_guard` and fail outside `LabVIEW-Community-CI-CD/labview-cdev-surface`.
 - `release-with-windows-gate.yml` must run Windows acceptance via `./.github/workflows/_windows-labview-image-gate-core.yml` before publish.
+- Windows gate runners must be preconfigured in Windows container mode; do not rely on interactive Docker engine switching in CI.
 - Publish is hard-blocked when Windows gate fails unless controlled override is explicitly enabled with complete metadata.
 - Controlled override requires all of:
   - `allow_gate_override=true`

--- a/README.md
+++ b/README.md
@@ -170,4 +170,4 @@ On failure, it updates a single tracking issue (`Nightly Supply-Chain Canary Fai
 ## Windows LabVIEW image gate
 
 `windows-labview-image-gate.yml` is dispatch-only and wraps `./.github/workflows/_windows-labview-image-gate-core.yml` for standalone diagnostics.  
-The core gate pulls `nationalinstruments/labview:latest-windows`, installs the NSIS workspace installer in-container, runs bundled `runner-cli ppl build` and `runner-cli vip build`, and verifies PPL + VIP output presence.
+The core gate requires the runner to already be in Windows container mode (non-interactive CI does not switch Docker engine), then pulls `nationalinstruments/labview:latest-windows`, installs the NSIS workspace installer in-container, runs bundled `runner-cli ppl build` and `runner-cli vip build`, and verifies PPL + VIP output presence.

--- a/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
+++ b/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
@@ -28,7 +28,8 @@ Describe 'Windows LabVIEW image gate workflow contract' {
     It 'targets windows containers with installer-post-action report checks in core workflow' {
         $script:coreWorkflowContent | Should -Match 'workflow_call:'
         $script:coreWorkflowContent | Should -Match 'nationalinstruments/labview:latest-windows'
-        $script:coreWorkflowContent | Should -Match 'DockerCli\.exe.*-SwitchWindowsEngine'
+        $script:coreWorkflowContent | Should -Match "docker version --format '\{\{\.Server\.Os\}\}'"
+        $script:coreWorkflowContent | Should -Match 'automatic engine switching is disabled for non-interactive CI'
         $script:coreWorkflowContent | Should -Match 'Install-WorkspaceFromManifest\.ps1'
         $script:coreWorkflowContent | Should -Match 'workspace-install-latest\.json'
         $script:coreWorkflowContent | Should -Match "ppl_capability_checks\.'32'\.status"


### PR DESCRIPTION
## Summary
- remove CI-time Docker engine switching from `_windows-labview-image-gate-core.yml`
- add non-interactive guard: require `docker version --format ''{{.Server.Os}}''` to be `windows`
- fail with explicit remediation message when runner is not preconfigured for Windows containers
- update gate contract test and docs/policy wording

## Why
`DockerCli.exe -SwitchWindowsEngine` can trigger interactive prompts and fails under runner service accounts (`Access is denied` on `dockerBackendApiServer` pipe).

## Validation
- `Invoke-Pester -Path @('./tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1','./tests/WorkspaceSurfaceContract.Tests.ps1') -CI`
- Result: 9 passed, 0 failed