### PR TITLE
feat: add Hyper-V fallback isolation for Windows gate

### DIFF
--- a/.github/workflows/_windows-labview-image-gate-core.yml
+++ b/.github/workflows/_windows-labview-image-gate-core.yml
@@ -72,13 +72,21 @@ jobs:
             throw "Failed to build installer for windows image gate."
           }
 
-      - name: Validate Windows container engine and pull image
+      - name: Validate Windows container engine and configure isolation
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $labviewImage = '${{ vars.LABVIEW_WINDOWS_IMAGE }}'
           if ([string]::IsNullOrWhiteSpace($labviewImage)) {
             $labviewImage = 'nationalinstruments/labview:2026q1-windows'
+          }
+          $requestedIsolation = '${{ vars.LABVIEW_WINDOWS_DOCKER_ISOLATION }}'
+          if ([string]::IsNullOrWhiteSpace($requestedIsolation)) {
+            $requestedIsolation = 'auto'
+          }
+          $requestedIsolation = $requestedIsolation.Trim().ToLowerInvariant()
+          if (@('auto', 'process', 'hyperv') -notcontains $requestedIsolation) {
+            throw "Invalid LABVIEW_WINDOWS_DOCKER_ISOLATION value '$requestedIsolation'. Supported values: auto, process, hyperv."
           }
 
           $serverOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim().ToLowerInvariant()
@@ -115,16 +123,30 @@ jobs:
 
           $hostVersionPrefix = Get-WindowsVersionPrefix -VersionString $hostKernelVersion
           $imageVersionPrefix = Get-WindowsVersionPrefix -VersionString $imageOsVersion
+
+          $effectiveIsolation = 'process'
           if ($hostVersionPrefix -ne $imageVersionPrefix) {
-            throw "Windows container compatibility mismatch. Host kernel '$hostKernelVersion' does not match image '$labviewImage' os.version '$imageOsVersion'. Use a runner host compatible with '$imageVersionPrefix' or set repository variable LABVIEW_WINDOWS_IMAGE to a compatible tag."
+            if ($requestedIsolation -eq 'process') {
+              throw "Windows container compatibility mismatch. Host kernel '$hostKernelVersion' does not match image '$labviewImage' os.version '$imageOsVersion'. LABVIEW_WINDOWS_DOCKER_ISOLATION is explicitly set to process, so fallback is disabled."
+            }
+            $effectiveIsolation = 'hyperv'
+            Write-Host "::warning::Windows container compatibility mismatch detected. Falling back to Hyper-V isolation for image '$labviewImage'. Host='$hostKernelVersion' Image='$imageOsVersion'."
+          } elseif ($requestedIsolation -eq 'hyperv') {
+            $effectiveIsolation = 'hyperv'
+            Write-Host "::notice::LABVIEW_WINDOWS_DOCKER_ISOLATION requests Hyper-V isolation for compatible host/image versions."
           }
 
-          docker pull $labviewImage
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to pull LabVIEW Windows image '$labviewImage'."
+          if ($effectiveIsolation -eq 'process') {
+            docker pull $labviewImage
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to pull LabVIEW Windows image '$labviewImage'."
+            }
+          } else {
+            Write-Host "Skipping explicit docker pull because effective isolation is '$effectiveIsolation'. The docker run step will resolve and pull image '$labviewImage' under Hyper-V isolation."
           }
 
           "LABVIEW_WINDOWS_IMAGE=$labviewImage" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "LABVIEW_WINDOWS_DOCKER_ISOLATION=$effectiveIsolation" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Run installer and runner-cli gate in Windows container
         shell: pwsh
@@ -177,8 +199,13 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($labviewImage)) {
             $labviewImage = 'nationalinstruments/labview:2026q1-windows'
           }
+          $dockerIsolation = [string]$env:LABVIEW_WINDOWS_DOCKER_ISOLATION
+          if ([string]::IsNullOrWhiteSpace($dockerIsolation)) {
+            $dockerIsolation = 'process'
+          }
 
           docker run --rm `
+            --isolation=$dockerIsolation `
             -v "${env:GITHUB_WORKSPACE}:C:\workspace" `
             $labviewImage `
             powershell -NoProfile -Command $containerCmd

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@ This repository is the canonical policy and manifest surface for deterministic `
 - Windows gate runners must be preconfigured in Windows container mode; do not rely on interactive Docker engine switching in CI.
 - Windows gate workflow must target labels: `self-hosted`, `windows`, `self-hosted-windows-lv`, `windows-containers`, `user-session`, `cdev-surface-windows-gate`.
 - Windows gate image default is `nationalinstruments/labview:2026q1-windows`; optional override via repository variable `LABVIEW_WINDOWS_IMAGE`.
+- Windows gate isolation policy:
+  - `LABVIEW_WINDOWS_DOCKER_ISOLATION=auto` (default): use `process` for compatible host/image versions and fallback to `hyperv` on mismatch.
+  - `LABVIEW_WINDOWS_DOCKER_ISOLATION=process`: strict process isolation only (mismatch is hard fail).
+  - `LABVIEW_WINDOWS_DOCKER_ISOLATION=hyperv`: force Hyper-V isolation.
 - Publish is hard-blocked when Windows gate fails unless controlled override is explicitly enabled with complete metadata.
 - Controlled override requires all of:
   - `allow_gate_override=true`

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ On failure, it updates a single tracking issue (`Nightly Supply-Chain Canary Fai
 `windows-labview-image-gate.yml` is dispatch-only and wraps `./.github/workflows/_windows-labview-image-gate-core.yml` for standalone diagnostics.  
 The core gate requires the runner to already be in Windows container mode (non-interactive CI does not switch Docker engine), validates host/image OS-version compatibility via `docker manifest inspect --verbose`, then pulls `nationalinstruments/labview:2026q1-windows` by default (override with repo variable `LABVIEW_WINDOWS_IMAGE`), installs the NSIS workspace installer in-container, runs bundled `runner-cli ppl build` and `runner-cli vip build`, and verifies PPL + VIP output presence.
 The core gate is pinned to dedicated labels so it runs only on the intended user-session runner lane: `self-hosted`, `windows`, `self-hosted-windows-lv`, `windows-containers`, `user-session`, `cdev-surface-windows-gate`.
+Isolation behavior is controlled by `LABVIEW_WINDOWS_DOCKER_ISOLATION`:
+1. `auto` (default): process isolation when host/image OS versions match, automatic Hyper-V fallback on mismatch.
+2. `process`: strict process isolation only (mismatch fails).
+3. `hyperv`: force Hyper-V isolation.
 
 ### Windows feature troubleshooting reporting
 

--- a/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
+++ b/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
@@ -30,9 +30,12 @@ Describe 'Windows LabVIEW image gate workflow contract' {
         $script:coreWorkflowContent | Should -Match 'runs-on:\s*\[self-hosted,\s*windows,\s*self-hosted-windows-lv,\s*windows-containers,\s*user-session,\s*cdev-surface-windows-gate\]'
         $script:coreWorkflowContent | Should -Match 'nationalinstruments/labview:2026q1-windows'
         $script:coreWorkflowContent | Should -Match 'LABVIEW_WINDOWS_IMAGE'
+        $script:coreWorkflowContent | Should -Match 'LABVIEW_WINDOWS_DOCKER_ISOLATION'
         $script:coreWorkflowContent | Should -Match "docker version --format '\{\{\.Server\.Os\}\}'"
         $script:coreWorkflowContent | Should -Match 'docker manifest inspect --verbose'
         $script:coreWorkflowContent | Should -Match 'Windows container compatibility mismatch'
+        $script:coreWorkflowContent | Should -Match 'Falling back to Hyper-V isolation'
+        $script:coreWorkflowContent | Should -Match '--isolation=\$dockerIsolation'
         $script:coreWorkflowContent | Should -Match 'automatic engine switching is disabled for non-interactive CI'
         $script:coreWorkflowContent | Should -Match 'Install-WorkspaceFromManifest\.ps1'
         $script:coreWorkflowContent | Should -Match 'workspace-install-latest\.json'

--- a/tests/WorkspaceSurfaceContract.Tests.ps1
+++ b/tests/WorkspaceSurfaceContract.Tests.ps1
@@ -131,11 +131,13 @@ Describe 'Workspace surface contract' {
 
     It 'documents Windows feature troubleshooting reporting contract for Docker gating' {
         $script:agentsContent | Should -Match 'LABVIEW_WINDOWS_IMAGE'
+        $script:agentsContent | Should -Match 'LABVIEW_WINDOWS_DOCKER_ISOLATION'
         $script:agentsContent | Should -Match 'NoRestart'
         $script:agentsContent | Should -Match 'features_enabled'
         $script:agentsContent | Should -Match 'reboot_pending'
         $script:agentsContent | Should -Match 'docker_daemon_ready'
         $script:readmeContent | Should -Match 'LABVIEW_WINDOWS_IMAGE'
+        $script:readmeContent | Should -Match 'LABVIEW_WINDOWS_DOCKER_ISOLATION'
         $script:readmeContent | Should -Match 'features_enabled'
         $script:readmeContent | Should -Match 'reboot_pending'
         $script:readmeContent | Should -Match 'docker_daemon_ready'


### PR DESCRIPTION
## Summary
- keep strict Windows host/image compatibility preflight in the Windows image gate
- add controlled Hyper-V isolation fallback when host/image versions do not match
- add `LABVIEW_WINDOWS_DOCKER_ISOLATION` policy variable (`auto|process|hyperv`)
- keep dedicated runner lane routing (`cdev-surface-windows-gate` + `user-session`)

## Behavior
- `auto` (default): process isolation on compatible host/image; fallback to hyperv on mismatch
- `process`: strict process isolation only (mismatch hard-fails)
- `hyperv`: force hyperv isolation

## Validation
- `Invoke-Pester -Path tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1 -CI`
- `Invoke-Pester` WorkspaceSurface contract with TestResult output disabled
