### PR TITLE
fix(gate): fail fast when pwsh is missing in windows image

### DIFF
--- a/.github/workflows/_windows-labview-image-gate-core.yml
+++ b/.github/workflows/_windows-labview-image-gate-core.yml
@@ -160,6 +160,10 @@ jobs:
 
           $containerCmd = @'
           $ErrorActionPreference = "Stop"
+          if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
+            throw "pwsh is not available in container image. Install PowerShell 7 or use an image that includes pwsh."
+          }
+
           & "C:\workspace\artifacts\windows-image-gate\lvie-cdev-workspace-installer.exe" /S
           if ($LASTEXITCODE -ne 0) { throw "Installer failed with exit code $LASTEXITCODE" }
 

--- a/nsis/workspace-bootstrap-installer.nsi
+++ b/nsis/workspace-bootstrap-installer.nsi
@@ -39,6 +39,12 @@ Section "Install"
   SetOutPath "$INSTDIR"
   File /r "${PAYLOAD_DIR}\*"
 
+  ExecWait '"$SYSDIR\cmd.exe" /c "where pwsh >nul 2>nul"' $0
+  ${If} $0 != 0
+    SetErrorLevel 9009
+    Abort
+  ${EndIf}
+
   ExecWait '"pwsh" -NoProfile -File "$INSTDIR\${INSTALL_SCRIPT_REL}" -WorkspaceRoot "${WORKSPACE_ROOT}" -ManifestPath "$INSTDIR\${MANIFEST_REL}" -Mode Install -ExecutionContext NsisInstall -OutputPath "${WORKSPACE_ROOT}\${REPORT_REL}"' $0
   ${If} $0 != 0
     SetErrorLevel $0

--- a/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
+++ b/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
@@ -37,6 +37,7 @@ Describe 'Windows LabVIEW image gate workflow contract' {
         $script:coreWorkflowContent | Should -Match 'Falling back to Hyper-V isolation'
         $script:coreWorkflowContent | Should -Match '--isolation=\$dockerIsolation'
         $script:coreWorkflowContent | Should -Match 'automatic engine switching is disabled for non-interactive CI'
+        $script:coreWorkflowContent | Should -Match 'Get-Command pwsh'
         $script:coreWorkflowContent | Should -Match 'Install-WorkspaceFromManifest\.ps1'
         $script:coreWorkflowContent | Should -Match 'workspace-install-latest\.json'
         $script:coreWorkflowContent | Should -Match "ppl_capability_checks\.'32'\.status"


### PR DESCRIPTION
## Summary
- fail fast in NSIS installer when `pwsh` is unavailable (exit code `9009`)
- add explicit `pwsh` availability check in Windows image gate container command
- lock this behavior with a workflow contract assertion

## Validation
- `Invoke-Pester -Path ./tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1 -CI -Output Detailed`
- `Invoke-Pester -Path ./tests/Build-WorkspaceBootstrapInstaller.Tests.ps1 -CI -Output Detailed`
- runtime container check on `nationalinstruments/labview:2026q1-windows` confirms installer exits `9009` when `pwsh` is absent