### PR TITLE
fix(gate): allow runner-cli bundle script on Windows PowerShell

### DIFF
--- a/scripts/Build-RunnerCliBundleFromManifest.ps1
+++ b/scripts/Build-RunnerCliBundleFromManifest.ps1
@@ -1,4 +1,3 @@
-#Requires -Version 7.0
 [CmdletBinding()]
 param(
     [Parameter()]


### PR DESCRIPTION
Remove PS7-only header requirement from scripts/Build-RunnerCliBundleFromManifest.ps1 so the Windows gate can execute under Windows PowerShell 5.1 without reintroducing pwsh in workflow shells. Validated with Windows gate + workspace contract tests.