### PR TITLE
fix(gate): pass deterministic bool args for Windows PowerShell

### DIFF
--- a/.github/workflows/_windows-labview-image-gate-core.yml
+++ b/.github/workflows/_windows-labview-image-gate-core.yml
@@ -54,7 +54,7 @@ jobs:
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic:$true
+            -Deterministic $true
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to build runner-cli bundle for windows image gate."
           }
@@ -100,7 +100,7 @@ jobs:
             -WorkspaceRootDefault 'C:\workspace\gate-dev' `
             -RequiredLabviewYear $requiredLabviewYear `
             -NsisRoot $nsisRoot `
-            -Deterministic:$true
+            -Deterministic $true
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to build installer for windows image gate."
           }

--- a/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
+++ b/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
@@ -67,6 +67,8 @@ Describe 'Windows LabVIEW image gate workflow contract' {
         $script:coreWorkflowContent | Should -Match '--mount "type=bind,source=\$hostGhRoot,target=C:\\host-tools\\GitHubCLI,readonly"'
         $script:coreWorkflowContent | Should -Match '--mount "type=bind,source=\$hostGCliRoot,target=C:\\host-tools\\G-CLI,readonly"'
         $script:coreWorkflowContent | Should -Match 'Install-WorkspaceFromManifest\.ps1'
+        $script:coreWorkflowContent | Should -Match '-Deterministic \$true'
+        $script:coreWorkflowContent | Should -Not -Match '-Deterministic:\$true'
         $script:coreWorkflowContent | Should -Match 'workspace-install-latest\.json'
         $script:coreWorkflowContent | Should -Match "ppl_capability_checks\.'32'\.status"
         $script:coreWorkflowContent | Should -Match "ppl_capability_checks\.'64'\.status"


### PR DESCRIPTION
Fixes upstream Windows gate failure where -Deterministic:True was bound as a string under Windows PowerShell 5.1 for [bool] parameters. Uses explicit -Deterministic True in gate script invocations and adds a workflow contract assertion preventing regression.