### PR TITLE
fix(gate): pass deterministic flag as numeric bool in child powershell calls

### DIFF
--- a/.github/workflows/_windows-labview-image-gate-core.yml
+++ b/.github/workflows/_windows-labview-image-gate-core.yml
@@ -54,7 +54,7 @@ jobs:
             -OutputRoot (Join-Path $payloadRoot 'tools/runner-cli/win-x64') `
             -RepoName 'labview-icon-editor' `
             -Runtime 'win-x64' `
-            -Deterministic $true
+            -Deterministic 1
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to build runner-cli bundle for windows image gate."
           }
@@ -100,7 +100,7 @@ jobs:
             -WorkspaceRootDefault 'C:\workspace\gate-dev' `
             -RequiredLabviewYear $requiredLabviewYear `
             -NsisRoot $nsisRoot `
-            -Deterministic $true
+            -Deterministic 1
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to build installer for windows image gate."
           }

--- a/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
+++ b/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
@@ -67,7 +67,8 @@ Describe 'Windows LabVIEW image gate workflow contract' {
         $script:coreWorkflowContent | Should -Match '--mount "type=bind,source=\$hostGhRoot,target=C:\\host-tools\\GitHubCLI,readonly"'
         $script:coreWorkflowContent | Should -Match '--mount "type=bind,source=\$hostGCliRoot,target=C:\\host-tools\\G-CLI,readonly"'
         $script:coreWorkflowContent | Should -Match 'Install-WorkspaceFromManifest\.ps1'
-        $script:coreWorkflowContent | Should -Match '-Deterministic \$true'
+        $script:coreWorkflowContent | Should -Match '-Deterministic 1'
+        $script:coreWorkflowContent | Should -Not -Match '-Deterministic \$true'
         $script:coreWorkflowContent | Should -Not -Match '-Deterministic:\$true'
         $script:coreWorkflowContent | Should -Match 'workspace-install-latest\.json'
         $script:coreWorkflowContent | Should -Match "ppl_capability_checks\.'32'\.status"


### PR DESCRIPTION
Follow-up for upstream gate run 22338975760: child powershell -File invocations still bound -Deterministic as a string under Windows PowerShell 5.1. This change passes numeric booleans (1) for deterministic flags and adds contract assertions preventing regressions to $true/:True forms in this workflow lane.