### PR TITLE
fix(gate): run installer workspace contract from C:\\dev root

### DIFF
--- a/.github/workflows/_windows-labview-image-gate-core.yml
+++ b/.github/workflows/_windows-labview-image-gate-core.yml
@@ -96,7 +96,7 @@ jobs:
           & powershell -NoProfile -ExecutionPolicy RemoteSigned -File "$env:GITHUB_WORKSPACE/scripts/Build-WorkspaceBootstrapInstaller.ps1" `
             -PayloadRoot $payloadRoot `
             -OutputPath $installerPath `
-            -WorkspaceRootDefault 'C:\workspace\gate-dev' `
+            -WorkspaceRootDefault 'C:\dev' `
             -RequiredLabviewYear $requiredLabviewYear `
             -NsisRoot $nsisRoot
           if ($LASTEXITCODE -ne 0) {
@@ -220,11 +220,11 @@ jobs:
             -ArgumentList '/S' `
             -Wait `
             -PassThru
-          $launchLogPath = "C:\workspace\gate-dev\artifacts\workspace-installer-launch.log"
+          $launchLogPath = "C:\dev\artifacts\workspace-installer-launch.log"
           if (Test-Path -LiteralPath $launchLogPath -PathType Leaf) {
             Copy-Item -LiteralPath $launchLogPath -Destination "C:\workspace\artifacts\windows-image-gate\workspace-installer-launch.log" -Force
           }
-          $installReportPath = "C:\workspace\gate-dev\artifacts\workspace-install-latest.json"
+          $installReportPath = "C:\dev\artifacts\workspace-install-latest.json"
           $installReportArtifactPath = "C:\workspace\artifacts\windows-image-gate\workspace-install-latest.json"
           $installReport = $null
           if (Test-Path -LiteralPath $installReportPath -PathType Leaf) {

--- a/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
+++ b/tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
@@ -47,6 +47,8 @@ Describe 'Windows LabVIEW image gate workflow contract' {
         $script:coreWorkflowContent | Should -Match 'LVIE_OFFLINE_GIT_MODE'
         $script:coreWorkflowContent | Should -Match 'LVIE_OFFLINE_GIT_MODE=true'
         $script:coreWorkflowContent | Should -Match '-RequiredLabviewYear \$requiredLabviewYear'
+        $script:coreWorkflowContent | Should -Match "-WorkspaceRootDefault 'C:\\dev'"
+        $script:coreWorkflowContent | Should -Not -Match 'C:\\workspace\\gate-dev'
         $script:coreWorkflowContent | Should -Match 'LVIE_LABVIEW_X86_NIPKG_INSTALL_CMD'
         $script:coreWorkflowContent | Should -Match 'LVIE_GATE_REQUIRED_LABVIEW_YEAR'
         $script:coreWorkflowContent | Should -Match 'LVIE_GATE_SINGLE_PPL_BITNESS'


### PR DESCRIPTION
Follow-up to #43.\n\nSummary:\n- set Build-WorkspaceBootstrapInstaller.ps1 -WorkspaceRootDefault to C:\\dev in Windows gate\n- read launch/install reports from C:\\dev\\artifacts in container step\n- keep artifact copy destination under C:\\workspace\\artifacts\\windows-image-gate\n\nWhy:\nCurrent upstream run 22339864258 fails preflight because LVIE_WORKTREE_ROOT is forced to C:\\workspace\\gate-dev while icon-editor repo roots are under C:\\dev, causing worktree guard failure.\n\nValidation:\n- tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1\n- tests/WorkspaceSurfaceContract.Tests.ps1\n- tests/WorkspaceInstallRuntimeContract.Tests.ps1\n- tests/Build-WorkspaceBootstrapInstaller.Tests.ps1