### PR TITLE
fix(gate): pin icon-editor resolver fix and harden runner-cli result handling

### DIFF
--- a/scripts/Install-WorkspaceFromManifest.ps1
+++ b/scripts/Install-WorkspaceFromManifest.ps1
@@ -547,8 +547,11 @@ function Invoke-RunnerCliPplCapabilityCheck {
         )
         $result.command = @($commandArgs)
 
-        & $RunnerCliPath @commandArgs
+        $runnerCliPplOutput = & $RunnerCliPath @commandArgs 2>&1
         $result.exit_code = $LASTEXITCODE
+        if ($null -ne $runnerCliPplOutput) {
+            $runnerCliPplOutput | ForEach-Object { Write-Host ([string]$_) }
+        }
         if ($result.exit_code -ne 0) {
             throw "runner-cli ppl build failed with exit code $($result.exit_code)."
         }
@@ -695,8 +698,11 @@ function Invoke-RunnerCliVipPackageHarnessCheck {
         )
         $result.command.vipc_assert = @($vipcAssertArgs)
         Write-InstallerFeedback -Message 'Running runner-cli vipc assert.'
-        & $RunnerCliPath @vipcAssertArgs
+        $vipcAssertOutput = & $RunnerCliPath @vipcAssertArgs 2>&1
         $vipcAssertExit = $LASTEXITCODE
+        if ($null -ne $vipcAssertOutput) {
+            $vipcAssertOutput | ForEach-Object { Write-Host ([string]$_) }
+        }
         if ($vipcAssertExit -ne 0) {
             $mismatchAssessment = Get-VipcMismatchAssessment `
                 -VipcAuditPath $vipcAuditPath `
@@ -723,8 +729,12 @@ function Invoke-RunnerCliVipPackageHarnessCheck {
                 }
 
                 Write-InstallerFeedback -Message 'Re-running runner-cli vipc assert after non-blocking remediation attempt.'
-                & $RunnerCliPath @vipcAssertArgs
-                if ($LASTEXITCODE -ne 0) {
+                $vipcAssertPostRemediationOutput = & $RunnerCliPath @vipcAssertArgs 2>&1
+                $vipcAssertPostRemediationExit = $LASTEXITCODE
+                if ($null -ne $vipcAssertPostRemediationOutput) {
+                    $vipcAssertPostRemediationOutput | ForEach-Object { Write-Host ([string]$_) }
+                }
+                if ($vipcAssertPostRemediationExit -ne 0) {
                     $postApplyAssessment = Get-VipcMismatchAssessment `
                         -VipcAuditPath $vipcAuditPath `
                         -NonBlockingRoots $nonBlockingVipcMismatchRoots
@@ -747,9 +757,13 @@ function Invoke-RunnerCliVipPackageHarnessCheck {
                 }
 
                 Write-InstallerFeedback -Message 'Re-running runner-cli vipc assert after apply.'
-                & $RunnerCliPath @vipcAssertArgs
-                if ($LASTEXITCODE -ne 0) {
-                    throw "runner-cli vipc assert failed after apply with exit code $LASTEXITCODE."
+                $vipcAssertPostApplyOutput = & $RunnerCliPath @vipcAssertArgs 2>&1
+                $vipcAssertPostApplyExit = $LASTEXITCODE
+                if ($null -ne $vipcAssertPostApplyOutput) {
+                    $vipcAssertPostApplyOutput | ForEach-Object { Write-Host ([string]$_) }
+                }
+                if ($vipcAssertPostApplyExit -ne 0) {
+                    throw "runner-cli vipc assert failed after apply with exit code $vipcAssertPostApplyExit."
                 }
             }
         }

--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -124,7 +124,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "4917e6bdf5bede718abb6cd900e0c3fa526f334b"
+      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -157,7 +157,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "4917e6bdf5bede718abb6cd900e0c3fa526f334b"
+      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -188,7 +188,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "4917e6bdf5bede718abb6cd900e0c3fa526f334b"
+      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -390,5 +390,4 @@
     }
   ]
 }
-
 

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -124,7 +124,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "4917e6bdf5bede718abb6cd900e0c3fa526f334b"
+      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -157,7 +157,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "4917e6bdf5bede718abb6cd900e0c3fa526f334b"
+      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -188,7 +188,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "4917e6bdf5bede718abb6cd900e0c3fa526f334b"
+      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -390,5 +390,4 @@
     }
   ]
 }
-
 


### PR DESCRIPTION
Follow-up to gate run 22339998332.\n\nSummary:\n- update icon-editor pinned SHA in both governance manifests to 70602062991ddc95fe11490655e6b209db6d2019 (merged upstream resolver PS5 compatibility fix)\n- prevent runner-cli process output from leaking into function return pipelines in Install-WorkspaceFromManifest.ps1\n\nWhy:\n- gate was still pinned to icon-editor commit with PS7-only resolver header, causing ScriptRequiresUnmatchedPSVersion in Windows PowerShell 5.1 lane\n- installer runtime hit The property 'status' cannot be found on this object when command output polluted structured return values\n\nValidation:\n- tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1\n- tests/WorkspaceSurfaceContract.Tests.ps1\n- tests/WorkspaceInstallRuntimeContract.Tests.ps1\n- tests/Build-WorkspaceBootstrapInstaller.Tests.ps1