### PR TITLE
chore(governance): pin icon-editor repos to 65b2fb1

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -124,7 +124,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
+      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -157,7 +157,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
+      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -188,7 +188,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
+      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -390,4 +390,3 @@
     }
   ]
 }
-

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -124,7 +124,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
+      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -157,7 +157,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
+      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -188,7 +188,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "70602062991ddc95fe11490655e6b209db6d2019"
+      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -390,4 +390,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
## Summary
- bump all icon-editor governance pins from 70602062991ddc95fe11490655e6b209db6d2019 to 65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70
- aligns surface installer/gate clone resolution with the merged icon-editor PowerShell 5.1 compatibility fix for Tooling/support/GcliRunner.ps1

## Validation
- pwsh -NoProfile -File tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
- pwsh -NoProfile -File tests/WorkspaceSurfaceContract.Tests.ps1
- pwsh -NoProfile -File tests/WorkspaceInstallRuntimeContract.Tests.ps1
- pwsh -NoProfile -File tests/Build-WorkspaceBootstrapInstaller.Tests.ps1