### PR TITLE
fix(governance): correct icon-editor pin sha for gate

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -124,7 +124,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
+      "pinned_sha": "65b2fb188b6d7e18e88af7a133344dddd6ff0445"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -157,7 +157,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
+      "pinned_sha": "65b2fb188b6d7e18e88af7a133344dddd6ff0445"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -188,7 +188,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
+      "pinned_sha": "65b2fb188b6d7e18e88af7a133344dddd6ff0445"
     },
     {
       "path": "C:\\dev\\labview-for-containers",

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -124,7 +124,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
+      "pinned_sha": "65b2fb188b6d7e18e88af7a133344dddd6ff0445"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -157,7 +157,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
+      "pinned_sha": "65b2fb188b6d7e18e88af7a133344dddd6ff0445"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -188,7 +188,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70"
+      "pinned_sha": "65b2fb188b6d7e18e88af7a133344dddd6ff0445"
     },
     {
       "path": "C:\\dev\\labview-for-containers",


### PR DESCRIPTION
## Summary
- correct icon-editor pinned_sha values in both governance manifests from non-existent 65b2fb11b8f00ed6705fd5dc10635fb2c8f8fd70
- set all three icon-editor entries to existing synced commit 65b2fb188b6d7e18e88af7a133344dddd6ff0445

## Why
windows-labview-image-gate failed in Build-RunnerCliBundleFromManifest.ps1 with:
- atal: unable to read tree (65b2fb11...)

## Validation
- pwsh -NoProfile -File tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1
- pwsh -NoProfile -File tests/WorkspaceSurfaceContract.Tests.ps1
- pwsh -NoProfile -File tests/WorkspaceInstallRuntimeContract.Tests.ps1
- pwsh -NoProfile -File tests/Build-WorkspaceBootstrapInstaller.Tests.ps1