### PR TITLE
Dispatch routing hardening: setup and actor label contracts

### DIFF
--- a/tests/StartSelfHostedMachineCertificationContract.Tests.ps1
+++ b/tests/StartSelfHostedMachineCertificationContract.Tests.ps1
@@ -37,5 +37,16 @@ Describe 'Start self-hosted machine certification dispatch contract' {
         $script:startScriptContent | Should -Match 'actions/runners/\{0\}/labels'
         $script:startScriptContent | Should -Match 'labels\[\]='
     }
+
+    It 'enforces setup/actor routing contract before dispatch' {
+        $script:startScriptContent | Should -Match 'function Get-SetupExpectedLabviewYear'
+        $script:startScriptContent | Should -Match 'function Test-SetupRequiresActorLabel'
+        $script:startScriptContent | Should -Match 'function Assert-DispatchRoutingContract'
+        $script:startScriptContent | Should -Match 'dispatch_routing_setup_label_missing'
+        $script:startScriptContent | Should -Match 'dispatch_routing_actor_label_missing'
+        $script:startScriptContent | Should -Match 'dispatch_routing_actor_label_mismatch'
+        $script:startScriptContent | Should -Match '\$routingContract = Assert-DispatchRoutingContract'
+        $script:startScriptContent | Should -Match 'routing_contract_requires_actor_label = \[bool\]\$routingContract\.requires_actor_label'
+    }
 }
 


### PR DESCRIPTION
Propagates fork commit ddc3c5358f66c32e2f5d54d0cffba0518f408d68 (dispatch-only hardening).\n\n- pre-dispatch setup/actor routing contract checks\n- fail-fast for missing or mismatched setup/actor labels\n- routing contract fields added to dispatch report\n- dispatch contract tests updated\n\nValidation:\n- pwsh -NoProfile -File tests/StartSelfHostedMachineCertificationContract.Tests.ps1\n- pwsh -NoProfile -File tests/MachineCertificationProfilesContract.Tests.ps1\n- pwsh -NoProfile -File tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1