### PR TITLE
Hotfix: avoid jq array indexing in PACKAGE_SETUPS_JSON

### DIFF
--- a/.github/workflows/self-hosted-machine-certification.yml
+++ b/.github/workflows/self-hosted-machine-certification.yml
@@ -317,7 +317,8 @@ jobs:
                   elif type == "array" then .[]
                   else empty
                   end
-                | select(type == "object" and .setup_name == $setup_name)
+                | select(type == "object")
+                | select(.setup_name == $setup_name)
               ]
           ' matrix.json)"
           if [[ -z "$PACKAGE_SETUPS_JSON" ]]; then


### PR DESCRIPTION
Follow-up jq filter safety fix for certification workflow_dispatch.