### PR TITLE
fix: make package setup jq extraction fail-safe

### DIFF
--- a/.github/workflows/self-hosted-machine-certification.yml
+++ b/.github/workflows/self-hosted-machine-certification.yml
@@ -310,7 +310,12 @@ jobs:
             PACKAGE_SETUP_TARGET="legacy-2020-desktop-windows"
           fi
           PACKAGE_SETUPS_JSON="$(jq -c --arg setup_name "$PACKAGE_SETUP_TARGET" '
-            [ .. | objects | select((.setup_name? // "") == $setup_name) ]
+            [
+              ..
+              | try (
+                  if (type == "object") and (((.["setup_name"] // "") | tostring) == $setup_name) then . else empty end
+                ) catch empty
+            ]
           ' matrix.json)"
           if [[ -z "$PACKAGE_SETUPS_JSON" ]]; then
             PACKAGE_SETUPS_JSON='[]'


### PR DESCRIPTION
## Summary\n- avoid jq array-index crashes in PACKAGE_SETUPS_JSON extraction\n- guard setup_name field lookup with explicit object gate + try/catch\n\n## Validation\n- pwsh -NoProfile -File tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1\n- pwsh -NoProfile -File tests/StartSelfHostedMachineCertificationContract.Tests.ps1