### PR TITLE
fix: avoid jq field-index in package setup selection

### DIFF
--- a/.github/workflows/self-hosted-machine-certification.yml
+++ b/.github/workflows/self-hosted-machine-certification.yml
@@ -310,12 +310,7 @@ jobs:
             PACKAGE_SETUP_TARGET="legacy-2020-desktop-windows"
           fi
           PACKAGE_SETUPS_JSON="$(jq -c --arg setup_name "$PACKAGE_SETUP_TARGET" '
-            [
-              ..
-              | try (
-                  if (type == "object") and (((.["setup_name"] // "") | tostring) == $setup_name) then . else empty end
-                ) catch empty
-            ]
+            [ .[] | select((tostring | contains("\"setup_name\":\"" + $setup_name + "\""))) ]
           ' matrix.json)"
           if [[ -z "$PACKAGE_SETUPS_JSON" ]]; then
             PACKAGE_SETUPS_JSON='[]'


### PR DESCRIPTION
## Summary\n- remove jq field-index access from PACKAGE_SETUPS_JSON selection\n- use element string-match to select requested setup deterministically\n\n## Validation\n- pwsh -NoProfile -File tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1\n- pwsh -NoProfile -File tests/StartSelfHostedMachineCertificationContract.Tests.ps1