### PR TITLE
fix: skip package setup selection for non-legacy dispatch

### DIFF
--- a/.github/workflows/self-hosted-machine-certification.yml
+++ b/.github/workflows/self-hosted-machine-certification.yml
@@ -309,9 +309,13 @@ jobs:
           else
             PACKAGE_SETUP_TARGET="legacy-2020-desktop-windows"
           fi
-          PACKAGE_SETUPS_JSON="$(jq -c --arg setup_name "$PACKAGE_SETUP_TARGET" '
-            [ .[] | select((tostring | contains("\"setup_name\":\"" + $setup_name + "\""))) ]
-          ' matrix.json)"
+          if [[ "$PACKAGE_SETUP_TARGET" == "legacy-2020-desktop-windows" ]]; then
+            PACKAGE_SETUPS_JSON="$(jq -c --arg setup_name "$PACKAGE_SETUP_TARGET" '
+              [ .[] | select(type == "object") | select((.setup_name // "") == $setup_name) ]
+            ' matrix.json)"
+          else
+            PACKAGE_SETUPS_JSON='[]'
+          fi
           if [[ -z "$PACKAGE_SETUPS_JSON" ]]; then
             PACKAGE_SETUPS_JSON='[]'
           fi


### PR DESCRIPTION
## Summary\n- for workflow_dispatch setups other than legacy-2020-desktop-windows, set PACKAGE_SETUPS_JSON=[]\n- keep legacy package setup selection path unchanged\n\n## Validation\n- pwsh -NoProfile -File tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1\n- pwsh -NoProfile -File tests/StartSelfHostedMachineCertificationContract.Tests.ps1