### PR TITLE
certification: harden setup resolution and package gating

### DIFF
--- a/.github/workflows/self-hosted-machine-certification.yml
+++ b/.github/workflows/self-hosted-machine-certification.yml
@@ -1460,6 +1460,7 @@ jobs:
 
   package-vip:
     name: Build VI Package From Certification Outputs (${{ matrix.setup_name }})
+    if: ${{ needs.resolve-setups.outputs.package_setups_json != '[]' }}
     needs:
       - resolve-setups
       - certify
@@ -2036,4 +2037,5 @@ jobs:
             ${{ steps.build-vip.outputs.vip_output_path }}
             ${{ steps.build-vip.outputs.vip_output_root }}
           if-no-files-found: error
+
 

--- a/tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1
+++ b/tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1
@@ -152,6 +152,7 @@ Describe 'Self-hosted machine certification workflow contract' {
 
     It 'builds VIP package in a downstream artifact-consuming job with VIPB contract mapping' {
         $script:workflowContent | Should -Match 'Build VI Package From Certification Outputs'
+        $script:workflowContent | Should -Match 'if:\s*\$\{\{\s*needs\.resolve-setups\.outputs\.package_setups_json != ''\[\]''\s*\}\}'
         $script:workflowContent | Should -Match 'package_setups_json'
         $script:workflowContent | Should -Match 'fromJson\(needs\.resolve-setups\.outputs\.package_setups_json\)'
         $script:workflowContent | Should -Match 'PACKAGE_SETUP_TARGET='


### PR DESCRIPTION
## Summary
- map host-2025-desktop-windows to a contract execution year deterministically
- make certification package job skip when package setup matrix resolves empty
- retain fail-closed behavior for unresolved setup/year mapping

## Validation
- pwsh -NoProfile -File tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1
- pwsh -NoProfile -File tests/StartSelfHostedMachineCertificationContract.Tests.ps1