### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -502,7 +502,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "831274953534adf0d69f6dcb3a4eaeae990fb3b0"
+      "pinned_sha": "fda45ac448d4b3dcf498bac291681b1dc3bc449d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -700,8 +700,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "75da65adc99760d72e7596f3dd48d92b4972f8bf"
+      "pinned_sha": "a5962debed4f94ca19ecf8ed87346b35568c0d64"
     }
   ]
 }
-

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -502,7 +502,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "831274953534adf0d69f6dcb3a4eaeae990fb3b0"
+      "pinned_sha": "fda45ac448d4b3dcf498bac291681b1dc3bc449d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -700,8 +700,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "75da65adc99760d72e7596f3dd48d92b4972f8bf"
+      "pinned_sha": "a5962debed4f94ca19ecf8ed87346b35568c0d64"
     }
   ]
 }
-


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 2
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/LabVIEW-Community-CI-CD/labview-cdev-surface/actions/runs/25164221924
- Merge strategy: squash auto-merge